### PR TITLE
add valid-modes

### DIFF
--- a/src/shared/specs/base.cljs
+++ b/src/shared/specs/base.cljs
@@ -23,6 +23,4 @@
 (def valid-actions #{:go :extract :verify :update :put :import :filter :switch-to :transform
                      :sign-in :sign-out :save :add :fork :create})
 
-(def valid-modes #{:view-mode :edit-mode})
-
-
+(def valid-modes #{:view-mode :edit-mode :auth :new-user :edit-profile :view-profile})


### PR DESCRIPTION
Adds new valid-modes to allow the overlays to be accessed.

Things to think about: 
1. Some overlays will not always be valid (like new-user for a recurring user)
2. Naming of the overlays, the names chosen now match the ones chosen in offcourse-web. 
